### PR TITLE
Added default responses in docs

### DIFF
--- a/docs/components.js
+++ b/docs/components.js
@@ -1,3 +1,5 @@
+const responses = require('./responses')
+
 module.exports = {
   components: {
     securitySchemes: {
@@ -15,30 +17,8 @@ module.exports = {
       },
       Image: {
         type: 'string',
-        description: 'Save Url String',
-        example: 'www.google.com'
-      },
-      ErrorJWT: {
-        type: 'object',
-        properties: {
-          message: {
-            type: 'string',
-            description: 'Jwt expired or Bearer Token Invalid',
-            example:
-            'Jwt expired or Bearer Token Invalid'
-          }
-        }
-      },
-      ErrorNoFoundJWT: {
-        type: 'object',
-        properties: {
-          message: {
-            type: 'string',
-            description: 'Message of error',
-            example:
-            'Please provided a token Bearer in authorization'
-          }
-        }
+        description: 'image url',
+        example: 'https://cohorte-enero-835eb560.s3.amazonaws.com/df112830-8691-4c65-bf79-a80749cebd0c.jpg'
       },
       Categories: {
         type: 'object',
@@ -53,7 +33,42 @@ module.exports = {
             example: 'news'
           }
         }
+      },
+      ValidationError: {
+        type: 'object',
+        properties: {
+          errors: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                msg: {
+                  type: 'string',
+                  example: 'param required'
+                },
+                param: {
+                  type: 'string',
+                  example: 'name'
+                },
+                location: {
+                  type: 'string',
+                  example: 'body'
+                }
+              }
+            }
+          }
+        }
+      },
+      BadRequest: {
+        type: 'object',
+        properties: {
+          error: {
+            type: 'string',
+            example: 'Related entity with id 500 not found. Not updated'
+          }
+        }
       }
-    }
+    },
+    ...responses
   }
 }

--- a/docs/components.js
+++ b/docs/components.js
@@ -20,20 +20,6 @@ module.exports = {
         description: 'image url',
         example: 'https://cohorte-enero-835eb560.s3.amazonaws.com/df112830-8691-4c65-bf79-a80749cebd0c.jpg'
       },
-      Categories: {
-        type: 'object',
-        description: 'Movie data',
-        properties: {
-          id: {
-            $ref: '#/components/schemas/Id'
-          },
-          name: {
-            type: 'string',
-            description: 'name of the categorie',
-            example: 'news'
-          }
-        }
-      },
       ValidationError: {
         type: 'object',
         properties: {
@@ -42,9 +28,13 @@ module.exports = {
             items: {
               type: 'object',
               properties: {
+                value: {
+                  description: 'value provided',
+                  example: 4
+                },
                 msg: {
                   type: 'string',
-                  example: 'param required'
+                  example: 'must be a string'
                 },
                 param: {
                   type: 'string',

--- a/docs/responses.js
+++ b/docs/responses.js
@@ -1,0 +1,119 @@
+module.exports = {
+  responses: {
+    Removed: {
+      description: 'Resource removed',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              msg: {
+                type: 'string',
+                example: 'Entity removed succesfully'
+              }
+            }
+          }
+        }
+      }
+    },
+    ValidationError: {
+      description: 'Validation Error',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/ValidationError'
+          }
+        }
+      }
+    },
+    BadRequest: {
+      description: 'Bad Request',
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/BadRequest'
+          }
+        }
+      }
+    },
+    ValidationOrBadRequest: {
+      description: 'Validation Error or Bad Request (Multiple schemas)',
+      content: {
+        'application/json': {
+          schema: {
+            oneOf: [
+              { $ref: '#/components/schemas/ValidationError' },
+              { $ref: '#/components/schemas/BadRequest' }
+            ]
+          }
+        }
+      }
+    },
+    Unauthorized: {
+      description: 'Missing or invalid token',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              error: {
+                type: 'string',
+                example: 'Bearer Token Invalid'
+              }
+            }
+          }
+        }
+      }
+    },
+    Forbidden: {
+      description: 'Forbidden resource',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              error: {
+                type: 'string',
+                example: 'Role admin required'
+              }
+            }
+          }
+        }
+      }
+    },
+    NotFound: {
+      description: 'Resource Not Found',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              error: {
+                type: 'string',
+                description: '',
+                example: 'Resource with id 1 not found'
+              }
+            }
+          }
+        }
+      }
+    },
+    InternalServerError: {
+      description: 'Internal Server Error',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              error: {
+                type: 'string',
+                description: '',
+                example: 'Error uploading the image'
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -8,7 +8,7 @@ const getTokenPayload = (req) => {
   const token = authToken && authToken.startsWith('Bearer ') && authToken.split(' ')[1]
   if (!token) {
     const error = new Error('Please provided a token Bearer in authorization')
-    error.status = 403
+    error.status = 401
     throw error
   }
   return verifyToken(token)
@@ -35,7 +35,7 @@ const isAuth = async (req, res, next) => {
     const token = getTokenPayload(req)
     const user = await userRepository.getById(token.userId)
     if (!user) {
-      return res.status(403).json({ error: 'Not found user with token provided.' })
+      return res.status(401).json({ error: 'Not found user with token provided.' })
     }
     req.authUser = user.dataValues
     next()
@@ -52,7 +52,7 @@ const isOwnUser = async (req, res, next) => {
 
     if (!user) {
       const error = new Error('Not found user with token provided.')
-      error.status = 403
+      error.status = 401
       throw error
     }
 

--- a/middlewares/files.js
+++ b/middlewares/files.js
@@ -53,7 +53,8 @@ function errorAsValidationError (msg, fieldName) {
     errors: [
       {
         msg,
-        param: fieldName
+        param: fieldName,
+        location: 'body'
       }
     ]
   }


### PR DESCRIPTION
## Summary

* ### added default responses in docs
* refactors in `docs/components.js`
* fix: details at throwing errors in responses

## Usage

Docs example of getById endpoint:

(Check `docs/responses.js` for all default responses)

```js
module.exports = {
  get: {
    security: [{ bearerAuth: [] }],
    tags: ['Categories'],
    description: 'Get one Category',
    operationId: 'getById',
    parameters: [
      {
        name: 'id',
        in: 'path',
        schema: {
          $ref: '#/components/schemas/Id'
        },
        required: true,
        description: 'A Category id'
      }
    ],
    responses: {
      200: {
        description: 'Get one category',
        content: {
          'application/json': {
            schema: {
              type: 'object',
              properties: {
                data: { $ref: '#/components/schemas/Categories' }
              }
            }
          }
        }
      },
      400: { // this response may not be needed in a getById, it is here for example purposes
        $ref: '#/components/responses/ValidationOrBadRequest'
      },
      401: {
        $ref: '#/components/responses/Unauthorized'
      },
      403: {
        $ref: '#/components/responses/Forbidden'
      },
      404: {
        $ref: '#/components/responses/NotFound'
      },
      500: {
        $ref: '#/components/responses/InternalServerError'
      }
    }
  }
}
```